### PR TITLE
Update model_zoo.py

### DIFF
--- a/fsdet/model_zoo/model_zoo.py
+++ b/fsdet/model_zoo/model_zoo.py
@@ -145,7 +145,7 @@ def get_config_file(config_path):
         str: the real path to the config file.
     """
     cfg_file = pkg_resources.resource_filename(
-        "fsdet.model_zoo", os.path.join("configs", config_path)
+        "fsdet", os.path.join("..", "configs", config_path)
     )
     if not os.path.exists(cfg_file):
         raise RuntimeError(

--- a/fsdet/model_zoo/model_zoo.py
+++ b/fsdet/model_zoo/model_zoo.py
@@ -5,7 +5,7 @@ from fsdet.modeling import build_model
 import os
 import pkg_resources
 from detectron2.checkpoint import DetectionCheckpointer
-from detectron2.config import get_cfg
+from fsdet.config import get_cfg
 
 
 class _ModelZooUrls(object):


### PR DESCRIPTION
As suggested in [MODEL_ZOO.md](https://github.com/ucbdrive/few-shot-object-detection/blob/master/docs/MODEL_ZOO.md), I tried running

```python
from fsdet import model_zoo
model = model_zoo.get(
   "COCO-detection/faster_rcnn_R_101_FPN_ft_all_1shot.yaml", trained=True)
```

However, that resulted in this error:

```python
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/src/few-shot-object-detection/fsdet/model_zoo/model_zoo.py", line 176, in get
    cfg.merge_from_file(cfg_file)
  File "/venv/lib/python3.7/site-packages/detectron2/config/config.py", line 54, in merge_from_file
    self.merge_from_other_cfg(loaded_cfg)
  File "/venv/lib/python3.7/site-packages/fvcore/common/config.py", line 123, in merge_from_other_cfg
    return super().merge_from_other_cfg(cfg_other)
  File "/venv/lib/python3.7/site-packages/yacs/config.py", line 217, in merge_from_other_cfg
    _merge_a_into_b(cfg_other, self, self, [])
  File "/venv/lib/python3.7/site-packages/yacs/config.py", line 478, in _merge_a_into_b
    _merge_a_into_b(v, b[k], root, key_list + [k])
  File "/venv/lib/python3.7/site-packages/yacs/config.py", line 478, in _merge_a_into_b
    _merge_a_into_b(v, b[k], root, key_list + [k])
  File "/venv/lib/python3.7/site-packages/yacs/config.py", line 491, in _merge_a_into_b
    raise KeyError("Non-existent config key: {}".format(full_key))
KeyError: 'Non-existent config key: MODEL.BACKBONE.FREEZE'
```

In 884c17f ("remove detectron2 dependencies") fsdet/config/config.py was removed and this was changed from `fsdet.config` to `detectron2.config`. However, fsdet/config/config.py was then added back in 3cab324 ("more updates") and this file was never updated to match. fsdet/config/config.py imports fsdet/config/default.py, which defines MODEL.BACKBONE.FREEZE, which resolves this problem.