### PR TITLE
Update prepare_voc_few_shot.py

### DIFF
--- a/datasets/prepare_voc_few_shot.py
+++ b/datasets/prepare_voc_few_shot.py
@@ -15,7 +15,7 @@ VOC_CLASSES = ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car',
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--seeds", type=int, nargs="+", default=[1, 20],
+    parser.add_argument("--seeds", type=int, nargs="+", default=[1, 30],
                         help="Range of seeds")
     args = parser.parse_args()
     return args


### PR DESCRIPTION
Create 29 seeds as the paper and READMEs indicate, instead of 19.

[datasets/README.md](https://github.com/ucbdrive/few-shot-object-detection/blob/master/datasets/README.md#pascal-voc) claims prepare_voc_few_shot.py creates 29 seeds (to augment split0, which is the same data split and training examples provided by Kang et al. (2019).), however, it only creates 19 splits. [docs/MODEL_ZOO.md](https://github.com/ucbdrive/few-shot-object-detection/blob/master/docs/MODEL_ZOO.md#results-over-30-seeds) also reports results averaged over 30 seeds; as does Section 4.2 (c) Results on PASCAL VOC and COCO.
